### PR TITLE
Add clang-9 Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Available images:
 - clang 6
 - clang 7
 - clang 8
+- clang 9
 - android-ndk-r18b
 - android-ndk-r19c
 - android-ndk-r20

--- a/images/clang-9/Dockerfile
+++ b/images/clang-9/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:18.04
+MAINTAINER Lucio Asnaghi <kunitoki@gmail.com>
+
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+        ca-certificates \
+        build-essential \
+        python \
+        ninja-build \
+        ccache \
+        xz-utils \
+        curl \
+        git \
+    && apt-get clean \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.sh -o /tmp/curl-install.sh \
+    && chmod u+x /tmp/curl-install.sh \
+    && mkdir /usr/bin/cmake \
+    && /tmp/curl-install.sh --skip-license --prefix=/usr/bin/cmake \
+    && rm /tmp/curl-install.sh
+
+RUN curl -SL http://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz | tar -xJC . \
+    && mv clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04 clang_9.0.0
+
+ENV PATH="/clang_9.0.0/bin:/usr/bin/cmake/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/clang_9.0.0/lib:${LD_LIBRARY_PATH}"
+ENV CC="/clang_9.0.0/bin/clang"
+ENV CXX="/clang_9.0.0/bin/clang++"


### PR DESCRIPTION
Hi @kunitoki,

In https://github.com/McMartin/FRUT, I'm [using the `kunitoki/clang-8` Docker image](https://github.com/McMartin/FRUT/blob/3052055ec4395676b9d9125b3ad77db6c8d527dc/.cirrus.yml#L7) to ensure that my C++ code is properly formatted with clang-format-8.0.0. Thanks a lot for providing this Docker image!

Now I would like to use the new `IndentPPDirectives: BeforeHash` option, which was added in clang-format-9.0.0, so I need a `clang-9` Docker image.